### PR TITLE
fix(ci): improve grouped logging output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,7 @@ jobs:
             run \
               --systems "${{ matrix.system }}" \
               --results=$HOME/omci.json
+              --github-output
 
       - name: Omnix results
         id: omci
@@ -86,7 +87,7 @@ jobs:
       - name: Push to cachix
         env:
           CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         if: env.BRANCH_NAME == 'main'
         run: |
           nix run github:juspay/cachix-push -- \


### PR DESCRIPTION
Refactored grouped logging to avoid redundant checks for GitHub Actions output.
Ensured cleaner and more structured execution for CI steps.

Fixes juspay#234